### PR TITLE
Add Content Showcase block with synced gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,19 @@ Notes:
 -   The gallery is hidden on mobile by default (toggle in Showcase Layout).
 -   The wrapper listens for `shown.fs.accordion` events. You can override the
     event name in Showcase Events if you later swap the source block.
+-   The contract is extendable: any interactive source that emits the configured
+    event with a stable `itemId` (and supports the showcase media field) can
+    drive the gallery.
 -   Each showcase instance is scoped to its wrapper, so multiple showcases on
     a page operate independently.
+
+Extensibility contract:
+
+-   Source block must emit a bubbling CustomEvent with `detail.itemId`.
+-   The wrapper listens on its root element for `sourceEventName` (default:
+    `shown.fs.accordion`).
+-   Each source item must have a stable `itemId` attribute.
+-   The item block must expose the showcase media field (`showcaseMediaId`).
 
 ### Token class selectors
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Extend core blocks with Bootstrap-style utility classes, breakpoint width contro
 
 ## Requirements
 
--   WordPress 6.5+
+-   WordPress 6.9+
 -   Node/npm to build assets (via `@wordpress/scripts`)
 
 ## Quick Start
@@ -16,6 +16,27 @@ Extend core blocks with Bootstrap-style utility classes, breakpoint width contro
 5. In the editor, select a supported block and open the inspector to apply classes.
 
 ## Editor Usage
+
+### Content Showcase (Accordion + Gallery)
+
+The Content Showcase block provides a two-column layout where an interactive
+source (accordion) drives a synced media gallery. It uses the Interactivity API
+to keep the gallery in sync when the active item changes.
+
+Quick steps:
+
+1. Insert `FS Content Showcase`.
+2. In the left column, insert `FS Accordion (Interactive)` and add items.
+3. On each accordion item, open "Showcase Media" and select an image or video.
+4. In the right column, insert `FS Showcase Gallery` (restricted to the wrapper).
+
+Notes:
+
+-   The gallery is hidden on mobile by default (toggle in Showcase Layout).
+-   The wrapper listens for `shown.fs.accordion` events. You can override the
+    event name in Showcase Events if you later swap the source block.
+-   Each showcase instance is scoped to its wrapper, so multiple showcases on
+    a page operate independently.
 
 ### Token class selectors
 
@@ -216,7 +237,9 @@ Custom blocks under `src/blocks/` are disabled by default. Use Settings > Fancy 
 -   `fs-blocks/dynamic-picture-block`: responsive picture element with optional aspect ratio, border, and radius utilities.
 -   `fs-blocks/alert`: alert variant selector; display tokens; padding and positive margin controls; RichText message content.
 -   `fs-blocks/accordion-interactive`: accordion container using WordPress Interactivity API; display/position/zindex tokens; padding and positive margin controls; optional "Open First Item" toggle; CustomEvents API (hide, hidden, show, shown).
--   `fs-blocks/accordion-item-interactive`: child accordion item with title and content; uses Interactivity API for state management.
+-   `fs-blocks/accordion-item-interactive`: child accordion item with title and content; uses Interactivity API for state management; optional showcase media picker when inside Content Showcase.
+-   `fs-blocks/content-showcase`: wrapper block that provides local context for a synced gallery; layout + mobile hide toggles; Interactivity API store for syncing active media.
+-   `fs-blocks/showcase-gallery`: gallery block that renders media from the showcase context; transition controls (fade/slide/zoom).
 -   `fs-blocks/tabs-interactive`: tabbed container using WordPress Interactivity API; display/position/zindex tokens; padding and positive margin controls; CustomEvents API (hide, hidden, show, shown).
 -   `fs-blocks/tab-item-interactive`: child tab item with title and content; uses Interactivity API for state management.
 -   `fs-blocks/modal`: modal dialog using WordPress Interactivity API with Bootstrap 5 animations; size options (small/default/large/xl/fullscreen); centered positioning; scrollable content; static backdrop; keyboard navigation (Tab/Shift+Tab focus trap, Escape to close); focus management; CustomEvents API (show, shown, hide, hidden); ARIA compliant with always-visible close button.
@@ -235,6 +258,8 @@ Note: `core/button` and `core/image` are enhanced via filters and inspector cont
 -   Custom play button inserts a `.fs-video-overlay` when a poster is present and starts playback on click.
 -   Modal Settings converts `core/button` markup into a `<button>` with `data-bs-toggle="modal"` and `data-bs-target="#modal-id"`.
 -   Carousel outputs Swiper markup with `data-swiper` configuration; Swiper assets are loaded on the front end only when the carousel block is present.
+-   Content Showcase collects accordion item media data on the server and emits it as local context; the showcase wrapper updates `activeItemId` on the `shown.fs.accordion` event.
+-   A render filter maintains a per-render context stack so the showcase gallery can SSR before the wrapper outputs its context.
 
 ## Development
 

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -112,6 +112,18 @@ function fs_core_enhancements_get_custom_blocks() {
 			),
 			'path' => $get_block_path( 'accordion-interactive' ),
 		],
+		'content-showcase' => [
+			'name' => 'fs-blocks/content-showcase',
+			'label' => __(
+				'Content Showcase',
+				'fancy-squares-core-enhancements'
+			),
+			'description' => __(
+				'Syncs an interactive source with a showcase gallery.',
+				'fancy-squares-core-enhancements'
+			),
+			'path' => $get_block_path( 'content-showcase' ),
+		],
 		'carousel' => [
 			'name' => 'fs-blocks/carousel',
 			'label' => __( 'Carousel', 'fancy-squares-core-enhancements' ),
@@ -179,6 +191,16 @@ function fs_core_enhancements_register_blocks() {
 				$accordion_item_path
 			);
 			register_block_type( $accordion_item_path );
+		}
+		if ( 'content-showcase' === $slug ) {
+			$showcase_gallery_path =
+				fs_core_enhancements_get_custom_blocks()['content-showcase']['path'];
+			$showcase_gallery_path = str_replace(
+				'/content-showcase',
+				'/showcase-gallery',
+				$showcase_gallery_path
+			);
+			register_block_type( $showcase_gallery_path );
 		}
 		if ( 'carousel' === $slug ) {
 			$carousel_path =

--- a/inc/render-filters/content-showcase-context.php
+++ b/inc/render-filters/content-showcase-context.php
@@ -75,22 +75,8 @@ if ( ! function_exists( 'fs_showcase_collect_accordion_data' ) ) {
 					: 0;
 
 				if ( $media_id ) {
-					$media_type = wp_attachment_is( 'video', $media_id )
-						? 'video'
-						: 'image';
-					$media_url = 'video' === $media_type
-						? wp_get_attachment_url( $media_id )
-						: wp_get_attachment_image_url( $media_id, 'large' );
 					$items_data[ $item_id ] = [
 						'id' => $media_id,
-						'url' => $media_url ? $media_url : '',
-						'type' => $media_type,
-						'alt' => 'image' === $media_type
-							? get_post_meta( $media_id, '_wp_attachment_image_alt', true )
-							: '',
-						'srcset' => 'image' === $media_type
-							? wp_get_attachment_image_srcset( $media_id, 'large' )
-							: '',
 						'hasMedia' => true,
 					];
 					if ( '' === $first_media_item_id ) {

--- a/inc/render-filters/content-showcase-context.php
+++ b/inc/render-filters/content-showcase-context.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Content Showcase context stack for nested block rendering.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'fs_showcase_context_stack_init' ) ) {
+	function fs_showcase_context_stack_init() {
+		if ( ! isset( $GLOBALS['fs_showcase_context_stack'] ) || ! is_array( $GLOBALS['fs_showcase_context_stack'] ) ) {
+			$GLOBALS['fs_showcase_context_stack'] = [];
+		}
+	}
+}
+
+if ( ! function_exists( 'fs_showcase_context_stack_push' ) ) {
+	function fs_showcase_context_stack_push( array $context ) {
+		fs_showcase_context_stack_init();
+		$GLOBALS['fs_showcase_context_stack'][] = $context;
+	}
+}
+
+if ( ! function_exists( 'fs_showcase_context_stack_pop' ) ) {
+	function fs_showcase_context_stack_pop() {
+		fs_showcase_context_stack_init();
+		array_pop( $GLOBALS['fs_showcase_context_stack'] );
+	}
+}
+
+if ( ! function_exists( 'fs_showcase_context_stack_peek' ) ) {
+	function fs_showcase_context_stack_peek() {
+		fs_showcase_context_stack_init();
+		if ( empty( $GLOBALS['fs_showcase_context_stack'] ) ) {
+			return null;
+		}
+		return $GLOBALS['fs_showcase_context_stack'][ array_key_last( $GLOBALS['fs_showcase_context_stack'] ) ];
+	}
+}
+
+if ( ! function_exists( 'fs_showcase_collect_accordion_data' ) ) {
+	function fs_showcase_collect_accordion_data( array $block ) {
+		$block_name = isset( $block['blockName'] ) ? $block['blockName'] : '';
+		if ( 'fs-blocks/accordion-interactive' === $block_name ) {
+			$items_data = [];
+			$first_item_id = '';
+			$first_media_item_id = '';
+			$attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] )
+				? $block['attrs']
+				: [];
+			$accordion_opens_first = ! empty( $attrs['openFirstItem'] );
+
+			$inner_blocks = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] )
+				? $block['innerBlocks']
+				: [];
+
+			foreach ( $inner_blocks as $accordion_item ) {
+				if ( empty( $accordion_item['blockName'] ) || 'fs-blocks/accordion-item-interactive' !== $accordion_item['blockName'] ) {
+					continue;
+				}
+				$item_attrs = isset( $accordion_item['attrs'] ) && is_array( $accordion_item['attrs'] )
+					? $accordion_item['attrs']
+					: [];
+				$item_id = isset( $item_attrs['itemId'] )
+					? sanitize_html_class( $item_attrs['itemId'] )
+					: '';
+				if ( '' === $item_id ) {
+					continue;
+				}
+				if ( '' === $first_item_id ) {
+					$first_item_id = $item_id;
+				}
+
+				$media_id = ! empty( $item_attrs['showcaseMediaId'] )
+					? (int) $item_attrs['showcaseMediaId']
+					: 0;
+
+				if ( $media_id ) {
+					$media_type = wp_attachment_is( 'video', $media_id )
+						? 'video'
+						: 'image';
+					$media_url = 'video' === $media_type
+						? wp_get_attachment_url( $media_id )
+						: wp_get_attachment_image_url( $media_id, 'large' );
+					$items_data[ $item_id ] = [
+						'id' => $media_id,
+						'url' => $media_url ? $media_url : '',
+						'type' => $media_type,
+						'alt' => 'image' === $media_type
+							? get_post_meta( $media_id, '_wp_attachment_image_alt', true )
+							: '',
+						'srcset' => 'image' === $media_type
+							? wp_get_attachment_image_srcset( $media_id, 'large' )
+							: '',
+						'hasMedia' => true,
+					];
+					if ( '' === $first_media_item_id ) {
+						$first_media_item_id = $item_id;
+					}
+				} else {
+					$items_data[ $item_id ] = [
+						'hasMedia' => false,
+					];
+				}
+			}
+
+			$active_item_id = '';
+			if (
+				$accordion_opens_first &&
+				'' !== $first_item_id &&
+				! empty( $items_data[ $first_item_id ]['hasMedia'] )
+			) {
+				$active_item_id = $first_item_id;
+			}
+			if ( '' === $active_item_id ) {
+				$active_item_id = $first_media_item_id;
+			}
+
+			return [
+				'itemsData' => $items_data,
+				'activeItemId' => $active_item_id,
+			];
+		}
+
+		$inner_blocks = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] )
+			? $block['innerBlocks']
+			: [];
+		foreach ( $inner_blocks as $inner_block ) {
+			$result = fs_showcase_collect_accordion_data( $inner_block );
+			if ( null !== $result ) {
+				return $result;
+			}
+		}
+
+		return null;
+	}
+}
+
+if ( ! function_exists( 'fs_showcase_pre_render_block' ) ) {
+	function fs_showcase_pre_render_block( $pre_render, $parsed_block, $parent_block ) {
+		if ( null !== $pre_render ) {
+			return $pre_render;
+		}
+
+		if ( empty( $parsed_block['blockName'] ) || 'fs-blocks/content-showcase' !== $parsed_block['blockName'] ) {
+			return $pre_render;
+		}
+
+		$accordion_data = fs_showcase_collect_accordion_data( $parsed_block );
+		if ( ! is_array( $accordion_data ) ) {
+			$accordion_data = [
+				'itemsData' => [],
+				'activeItemId' => '',
+			];
+		}
+
+		fs_showcase_context_stack_push( $accordion_data );
+
+		return $pre_render;
+	}
+	add_filter( 'pre_render_block', 'fs_showcase_pre_render_block', 10, 3 );
+}
+
+if ( ! function_exists( 'fs_showcase_render_block' ) ) {
+	function fs_showcase_render_block( $block_content, $block ) {
+		if ( isset( $block['blockName'] ) && 'fs-blocks/content-showcase' === $block['blockName'] ) {
+			fs_showcase_context_stack_pop();
+		}
+		return $block_content;
+	}
+	add_filter( 'render_block', 'fs_showcase_render_block', 10, 2 );
+}

--- a/src/blocks/accordion-interactive/style.scss
+++ b/src/blocks/accordion-interactive/style.scss
@@ -44,3 +44,25 @@
 		padding: 1rem;
 	}
 }
+
+.fs-accordion-item__showcase-media {
+	display: block;
+	margin-bottom: 1rem;
+
+	img,
+	video {
+		width: 100%;
+		height: auto;
+		display: block;
+	}
+}
+
+.wp-block-fs-blocks-content-showcase {
+	.fs-accordion-item__showcase-media {
+		display: block;
+
+		@media ( min-width: 768px ) {
+			display: none;
+		}
+	}
+}

--- a/src/blocks/accordion-item-interactive/block.json
+++ b/src/blocks/accordion-item-interactive/block.json
@@ -25,9 +25,24 @@
 		"title": {
 			"type": "string",
 			"default": ""
+		},
+		"showcaseMedia": {
+			"type": "object",
+			"default": {}
+		},
+		"showcaseMediaId": {
+			"type": "number",
+			"default": 0
+		},
+		"showcaseMediaType": {
+			"type": "string",
+			"default": ""
 		}
 	},
-	"usesContext": [ "fs-blocks/accordion-interactive/activeItem" ],
+	"usesContext": [
+		"fs-blocks/accordion-interactive/activeItem",
+		"fs-blocks/content-showcase/isShowcase"
+	],
 	"editorScript": "file:./index.js",
 	"render": "file:./render.php"
 }

--- a/src/blocks/accordion-item-interactive/edit.js
+++ b/src/blocks/accordion-item-interactive/edit.js
@@ -3,7 +3,11 @@ import {
 	RichText,
 	InnerBlocks,
 	store as blockEditorStore,
+	InspectorControls,
+	MediaUpload,
+	MediaUploadCheck,
 } from '@wordpress/block-editor';
+import { PanelBody, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -17,7 +21,9 @@ export default function Edit( {
 	setAttributes,
 	context,
 } ) {
-	const { title, itemId } = attributes;
+	const { title, itemId, showcaseMedia, showcaseMediaId, showcaseMediaType } =
+		attributes;
+	const previewMediaType = showcaseMediaType || showcaseMedia?.type || '';
 
 	useEffect( () => {
 		if ( ! itemId ) {
@@ -27,6 +33,8 @@ export default function Edit( {
 
 	const activeItem = context[ 'fs-blocks/accordion-interactive/activeItem' ];
 	const isActiveItem = activeItem === ( itemId || clientId );
+	const isInsideShowcase =
+		context?.[ 'fs-blocks/content-showcase/isShowcase' ] || false;
 
 	// Get parent block ID
 	const parentClientId = useSelect(
@@ -43,6 +51,35 @@ export default function Edit( {
 	const blockProps = useBlockProps( {
 		className: `fs-accordion__item ${ isActiveItem ? 'is-active' : '' }`,
 	} );
+
+	const onSelectShowcaseMedia = ( media ) => {
+		if ( ! media?.id || ! media?.url ) {
+			return;
+		}
+
+		const mediaType = media?.type || media?.media_type || '';
+		const mimeType = media?.mime || media?.mime_type || '';
+
+		setAttributes( {
+			showcaseMedia: {
+				id: media.id,
+				url: media.url,
+				alt: media.alt || '',
+				type: mediaType,
+				mime: mimeType,
+			},
+			showcaseMediaId: media.id,
+			showcaseMediaType: mediaType,
+		} );
+	};
+
+	const onRemoveShowcaseMedia = () => {
+		setAttributes( {
+			showcaseMedia: {},
+			showcaseMediaId: 0,
+			showcaseMediaType: '',
+		} );
+	};
 
 	// Handle clicks on the trigger for editor UI only (not persisted to post_content)
 	const handleTriggerClick = ( e ) => {
@@ -65,42 +102,103 @@ export default function Edit( {
 	};
 
 	return (
-		<div { ...blockProps }>
-			<h3 className="fs-accordion__header">
-				<div
-					className="fs-accordion__trigger"
-					onClick={ handleTriggerClick }
-					style={ { cursor: 'pointer' } }
-					role="button"
-					tabIndex={ 0 }
-				>
-					<RichText
-						tagName="span"
-						value={ title }
-						onChange={ ( newTitle ) =>
-							setAttributes( { title: newTitle } )
-						}
-						placeholder={ __(
-							'Accordion Item Title',
-							TEXT_DOMAIN
+		<>
+			{ isInsideShowcase && (
+				<InspectorControls>
+					<PanelBody
+						title={ __( 'Showcase Media', TEXT_DOMAIN ) }
+						initialOpen={ false }
+					>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ onSelectShowcaseMedia }
+								allowedTypes={ [ 'image', 'video' ] }
+								value={ showcaseMediaId }
+								render={ ( { open } ) => (
+									<Button
+										variant="secondary"
+										onClick={ open }
+									>
+										{ showcaseMediaId
+											? __( 'Change Media', TEXT_DOMAIN )
+											: __(
+													'Select Image or Video',
+													TEXT_DOMAIN
+											  ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+						{ showcaseMedia?.url && (
+							<div style={ { marginTop: '1rem' } }>
+								{ previewMediaType === 'video' ? (
+									<video
+										src={ showcaseMedia.url }
+										controls
+										style={ {
+											width: '100%',
+											display: 'block',
+										} }
+									/>
+								) : (
+									<img
+										src={ showcaseMedia.url }
+										alt={ showcaseMedia.alt || '' }
+										style={ {
+											width: '100%',
+											display: 'block',
+										} }
+									/>
+								) }
+								<Button
+									variant="tertiary"
+									onClick={ onRemoveShowcaseMedia }
+									style={ { marginTop: '0.5rem' } }
+								>
+									{ __( 'Remove Media', TEXT_DOMAIN ) }
+								</Button>
+							</div>
 						) }
-						allowedFormats={ [] }
-						onClick={ ( e ) => e.stopPropagation() }
-					/>
-				</div>
-			</h3>
-			<div
-				className={ `fs-accordion__content${
-					isActiveItem ? ' is-open' : ''
-				}` }
-				style={ {
-					display: isActiveItem ? 'block' : 'none',
-				} }
-			>
-				<div className="fs-accordion__body">
-					<InnerBlocks />
+					</PanelBody>
+				</InspectorControls>
+			) }
+			<div { ...blockProps }>
+				<h3 className="fs-accordion__header">
+					<div
+						className="fs-accordion__trigger"
+						onClick={ handleTriggerClick }
+						style={ { cursor: 'pointer' } }
+						role="button"
+						tabIndex={ 0 }
+					>
+						<RichText
+							tagName="span"
+							value={ title }
+							onChange={ ( newTitle ) =>
+								setAttributes( { title: newTitle } )
+							}
+							placeholder={ __(
+								'Accordion Item Title',
+								TEXT_DOMAIN
+							) }
+							allowedFormats={ [] }
+							onClick={ ( e ) => e.stopPropagation() }
+						/>
+					</div>
+				</h3>
+				<div
+					className={ `fs-accordion__content${
+						isActiveItem ? ' is-open' : ''
+					}` }
+					style={ {
+						display: isActiveItem ? 'block' : 'none',
+					} }
+				>
+					<div className="fs-accordion__body">
+						<InnerBlocks />
+					</div>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/src/blocks/accordion-item-interactive/edit.js
+++ b/src/blocks/accordion-item-interactive/edit.js
@@ -106,7 +106,17 @@ export default function Edit( {
 			{ isInsideShowcase && (
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Showcase Media', TEXT_DOMAIN ) }
+						title={
+							<span className="fs-panel-title">
+								{ __( 'Showcase Media', TEXT_DOMAIN ) }
+								{ showcaseMediaId ? (
+									<span
+										className="fs-panel-indicator"
+										aria-hidden="true"
+									/>
+								) : null }
+							</span>
+						}
 						initialOpen={ false }
 					>
 						<MediaUploadCheck>

--- a/src/blocks/accordion-item-interactive/render.php
+++ b/src/blocks/accordion-item-interactive/render.php
@@ -11,6 +11,9 @@ defined( 'ABSPATH' ) || exit;
 
 $item_id = isset( $attributes['itemId'] ) ? sanitize_html_class( $attributes['itemId'] ) : '';
 $title   = isset( $attributes['title'] ) ? $attributes['title'] : '';
+$showcase_media_id = ! empty( $attributes['showcaseMediaId'] )
+	? (int) $attributes['showcaseMediaId']
+	: 0;
 
 if ( '' === $item_id ) {
 	$item_id = wp_unique_id( 'accordion-item-' );
@@ -26,6 +29,42 @@ $wrapper_attributes = get_block_wrapper_attributes();
 $item_context = [
 	'itemId' => $item_id,
 ];
+
+$showcase_media_markup = '';
+if ( $showcase_media_id ) {
+	$media_type = wp_attachment_is( 'video', $showcase_media_id )
+		? 'video'
+		: 'image';
+	ob_start();
+	?>
+	<div class="fs-accordion-item__showcase-media">
+		<?php if ( 'video' === $media_type ) : ?>
+			<video
+				class="fs-accordion-item__showcase-video"
+				data-fs-lazy-video="true"
+				data-src="<?php echo esc_url( wp_get_attachment_url( $showcase_media_id ) ); ?>"
+				autoplay
+				muted
+				loop
+				playsinline
+			></video>
+		<?php else : ?>
+			<?php
+			echo wp_get_attachment_image(
+				$showcase_media_id,
+				'large',
+				false,
+				[
+					'loading' => 'lazy',
+					'decoding' => 'async',
+				]
+			);
+			?>
+		<?php endif; ?>
+	</div>
+	<?php
+	$showcase_media_markup = ob_get_clean();
+}
 
 ?>
 <div
@@ -59,6 +98,7 @@ $item_context = [
 		data-item-id="<?php echo esc_attr( $item_id ); ?>"
 	>
 		<div class="fs-accordion__body">
+			<?php echo $showcase_media_markup; ?>
 			<?php echo $content; ?>
 		</div>
 	</div>

--- a/src/blocks/content-showcase/README.md
+++ b/src/blocks/content-showcase/README.md
@@ -1,0 +1,86 @@
+# FS Content Showcase Block
+
+## Purpose
+
+Wrapper block that syncs an interactive source (default: accordion) with a
+showcase gallery. It provides local Interactivity API context so the gallery
+and any other children can react to the active item.
+
+## Structure
+
+- Wrapper: `fs-blocks/content-showcase`
+- Source (left column): `fs-blocks/accordion-interactive`
+- Gallery (right column): `fs-blocks/showcase-gallery`
+
+The gallery is restricted via `ancestor` so it must live inside the wrapper.
+WordPress 6.9+ is required for `ancestor` support.
+
+## Data Flow (Runtime)
+
+1. Wrapper computes `itemsData` + `activeItemId` on the server.
+2. Wrapper outputs `data-wp-context` with those values.
+3. Wrapper listens for the source event and updates `activeItemId`.
+4. Gallery uses derived state to show the active media.
+
+## Interactivity API
+
+- Context is local and inherited by descendants.
+- Derived state in `view.js` reads `context.activeItemId`.
+- Updates happen through `getContext()` inside callbacks.
+- The wrapper updates `activeItemId`, so all children stay in sync.
+
+Why local context (not global state):
+
+- The gallery is a descendant of the wrapper, so local context naturally scopes
+  state per showcase instance.
+- Global state is best for sibling/remote blocks (e.g., filter + results),
+  which is not the case here.
+
+## Event Contract (Extensible)
+
+- Source must emit a bubbling CustomEvent with `detail.itemId`.
+- Wrapper listens on its root element for `sourceEventName`.
+- Each source item must have a stable `itemId`.
+- The item block must expose `showcaseMediaId`.
+
+## Example Extension (Tabs)
+
+Goal: use `fs-blocks/tabs-interactive` as the source instead of the accordion.
+
+1. Add showcase media attributes to the tab item block (same as accordion item).
+2. When a tab is activated, dispatch a bubbling event with `detail.itemId`.
+3. Set the wrapper `sourceEventName` to the tabs event.
+
+Sample event dispatch (tabs item view.js):
+
+```js
+const event = new CustomEvent( 'shown.fs.tabs', {
+	bubbles: true,
+	detail: { itemId: context.itemId },
+} );
+ref.dispatchEvent( event );
+```
+
+Then set `sourceEventName` on the wrapper to `shown.fs.tabs`.
+
+## SSR Context Stack
+
+WordPress renders inner blocks before the parent render callback. The gallery
+needs access to `itemsData` during server render, so a render filter maintains a
+per-render context stack:
+
+- `inc/render-filters/content-showcase-context.php` pushes data on pre-render.
+- The wrapper reads the stack when emitting `data-wp-context`.
+- The gallery reads the same stack for SSR output.
+
+## Media Notes
+
+- Videos use `data-fs-lazy-video` and are loaded by `src/frontend.js`.
+
+## Key Files
+
+- `block.json` - attributes, supports, providesContext
+- `edit.js` - editor UI, layout settings, source event name
+- `render.php` - computes context, emits `data-wp-context`
+- `view.js` - event listener + derived state
+- `style.scss` / `editor.scss` - layout and editor hints

--- a/src/blocks/content-showcase/block.json
+++ b/src/blocks/content-showcase/block.json
@@ -1,0 +1,54 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "fs-blocks/content-showcase",
+	"title": "FS Content Showcase",
+	"category": "layout",
+	"icon": "columns",
+	"description": "Wrapper block that syncs accordion items with a showcase gallery.",
+	"keywords": [ "showcase", "accordion", "gallery", "layout" ],
+	"textdomain": "fancy-squares-core-enhancements",
+	"supports": {
+		"html": false,
+		"anchor": true,
+		"__experimentalLayout": true,
+		"interactivity": true
+	},
+	"attributes": {
+		"blockId": {
+			"type": "string",
+			"default": ""
+		},
+		"isShowcase": {
+			"type": "boolean",
+			"default": true
+		},
+		"layoutType": {
+			"type": "string",
+			"default": "two-column"
+		},
+		"hideGalleryOnMobile": {
+			"type": "boolean",
+			"default": true
+		},
+		"sourceEventName": {
+			"type": "string",
+			"default": "shown.fs.accordion"
+		},
+		"additionalClasses": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"default": []
+		}
+	},
+	"providesContext": {
+		"fs-blocks/content-showcase/isShowcase": "isShowcase"
+	},
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"editorStyle": "file:./index.css",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/src/blocks/content-showcase/edit.js
+++ b/src/blocks/content-showcase/edit.js
@@ -1,0 +1,153 @@
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	SelectControl,
+	ToggleControl,
+	TextControl,
+} from '@wordpress/components';
+import { useEffect, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+import BlockEdit from '../../components/BlockEdit';
+import { generateClassName } from '../../utils/helpers';
+import { BLOCK_CONFIG } from '../../config/blockConfig';
+
+const TEXT_DOMAIN = 'fancy-squares-core-enhancements';
+
+const TEMPLATE = [
+	[
+		'core/columns',
+		{ className: 'fs-content-showcase__columns' },
+		[
+			[
+				'core/column',
+				{
+					className:
+						'fs-content-showcase__column fs-content-showcase__column--content',
+				},
+				[ [ 'fs-blocks/accordion-interactive' ] ],
+			],
+			[
+				'core/column',
+				{
+					className:
+						'fs-content-showcase__column fs-content-showcase__column--media',
+				},
+				[ [ 'fs-blocks/showcase-gallery' ] ],
+			],
+		],
+	],
+];
+
+const LAYOUT_OPTIONS = [
+	{ label: __( 'Two Column', TEXT_DOMAIN ), value: 'two-column' },
+	{ label: __( 'Sidebar Left', TEXT_DOMAIN ), value: 'sidebar-left' },
+	{ label: __( 'Sidebar Right', TEXT_DOMAIN ), value: 'sidebar-right' },
+];
+
+export default function Edit( props ) {
+	const { attributes, setAttributes, clientId, name } = props;
+	const {
+		blockId,
+		layoutType,
+		hideGalleryOnMobile,
+		sourceEventName,
+		additionalClasses,
+	} = attributes;
+
+	const generatedClassName = useMemo(
+		() => generateClassName( attributes, name, BLOCK_CONFIG ),
+		[ attributes, name ]
+	);
+
+	useEffect( () => {
+		const nextClasses = generatedClassName.split( /\s+/ ).filter( Boolean );
+		const currentClasses = Array.isArray( additionalClasses )
+			? additionalClasses
+			: [];
+		if ( currentClasses.join( ' ' ) !== nextClasses.join( ' ' ) ) {
+			setAttributes( { additionalClasses: nextClasses } );
+		}
+	}, [ additionalClasses, generatedClassName, setAttributes ] );
+
+	useEffect( () => {
+		if ( ! blockId ) {
+			setAttributes( { blockId: clientId } );
+		}
+	}, [ blockId, clientId, setAttributes ] );
+
+	const layoutClass = layoutType
+		? `fs-content-showcase--layout-${ layoutType }`
+		: '';
+	const hideClass = hideGalleryOnMobile
+		? 'fs-content-showcase--hide-gallery-mobile'
+		: '';
+
+	const blockProps = useBlockProps( {
+		className: [
+			'fs-content-showcase',
+			'd-block',
+			layoutClass,
+			hideClass,
+			generatedClassName,
+		]
+			.filter( Boolean )
+			.join( ' ' ),
+	} );
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: TEMPLATE,
+		templateLock: false,
+	} );
+
+	return (
+		<>
+			<BlockEdit { ...props } />
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Showcase Layout', TEXT_DOMAIN ) }
+					initialOpen={ false }
+				>
+					<SelectControl
+						label={ __( 'Layout', TEXT_DOMAIN ) }
+						value={ layoutType }
+						options={ LAYOUT_OPTIONS }
+						onChange={ ( value ) =>
+							setAttributes( { layoutType: value } )
+						}
+					/>
+					<ToggleControl
+						label={ __( 'Hide gallery on mobile', TEXT_DOMAIN ) }
+						checked={ hideGalleryOnMobile }
+						onChange={ () =>
+							setAttributes( {
+								hideGalleryOnMobile: ! hideGalleryOnMobile,
+							} )
+						}
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Showcase Events', TEXT_DOMAIN ) }
+					initialOpen={ false }
+				>
+					<TextControl
+						label={ __( 'Source event name', TEXT_DOMAIN ) }
+						value={ sourceEventName }
+						onChange={ ( value ) =>
+							setAttributes( { sourceEventName: value } )
+						}
+						help={ __(
+							'Event emitted by the source block to change active media.',
+							TEXT_DOMAIN
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...innerBlocksProps } />
+		</>
+	);
+}

--- a/src/blocks/content-showcase/editor.scss
+++ b/src/blocks/content-showcase/editor.scss
@@ -1,0 +1,4 @@
+.wp-block-fs-blocks-content-showcase {
+	border: 1px dashed #d0d0d0;
+	padding: 1rem;
+}

--- a/src/blocks/content-showcase/index.js
+++ b/src/blocks/content-showcase/index.js
@@ -1,0 +1,23 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+import metadata from './block.json';
+import edit from './edit';
+import { generateAttributes } from '../../utils/helpers';
+import './style.scss';
+import './editor.scss';
+
+export function registerContentShowcaseBlock() {
+	const attributes = {
+		...metadata.attributes,
+		...generateAttributes(),
+	};
+
+	registerBlockType( metadata.name, {
+		...metadata,
+		attributes,
+		edit,
+		save: () => <InnerBlocks.Content />,
+	} );
+}
+
+registerContentShowcaseBlock();

--- a/src/blocks/content-showcase/render.php
+++ b/src/blocks/content-showcase/render.php
@@ -77,22 +77,8 @@ $find_accordion_data = function( $block_instance ) use ( &$find_accordion_data )
 				: 0;
 
 			if ( $media_id ) {
-				$media_type = wp_attachment_is( 'video', $media_id )
-					? 'video'
-					: 'image';
-				$media_url = 'video' === $media_type
-					? wp_get_attachment_url( $media_id )
-					: wp_get_attachment_image_url( $media_id, 'large' );
 				$items_data[ $item_id ] = [
 					'id' => $media_id,
-					'url' => $media_url ? $media_url : '',
-					'type' => $media_type,
-					'alt' => 'image' === $media_type
-						? get_post_meta( $media_id, '_wp_attachment_image_alt', true )
-						: '',
-					'srcset' => 'image' === $media_type
-						? wp_get_attachment_image_srcset( $media_id, 'large' )
-						: '',
 					'hasMedia' => true,
 				];
 

--- a/src/blocks/content-showcase/render.php
+++ b/src/blocks/content-showcase/render.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Render callback for the Content Showcase block.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block inner content.
+ * @param WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$block_id_source = isset( $attributes['blockId'] ) ? $attributes['blockId'] : '';
+$block_id = '' !== $block_id_source
+	? sanitize_html_class( $block_id_source )
+	: wp_unique_id( 'showcase-' );
+
+$layout_type = isset( $attributes['layoutType'] )
+	? sanitize_key( $attributes['layoutType'] )
+	: 'two-column';
+$hide_gallery = ! empty( $attributes['hideGalleryOnMobile'] );
+$source_event_name = isset( $attributes['sourceEventName'] )
+	? sanitize_text_field( $attributes['sourceEventName'] )
+	: 'shown.fs.accordion';
+
+$classes = [ 'fs-content-showcase', 'd-block' ];
+if ( $layout_type ) {
+	$classes[] = 'fs-content-showcase--layout-' . $layout_type;
+}
+if ( $hide_gallery ) {
+	$classes[] = 'fs-content-showcase--hide-gallery-mobile';
+}
+
+if (
+	! empty( $attributes['additionalClasses'] ) &&
+	is_array( $attributes['additionalClasses'] )
+) {
+	foreach ( $attributes['additionalClasses'] as $class_name ) {
+		if ( is_string( $class_name ) && '' !== $class_name ) {
+			$classes[] = sanitize_html_class( $class_name );
+		}
+	}
+}
+
+/**
+ * Recursively find the first accordion block and collect media data from its items.
+ *
+ * @param WP_Block $block_instance Block instance to search.
+ * @return array|null Array with keys: itemsData, activeItemId, or null if not found.
+ */
+$find_accordion_data = function( $block_instance ) use ( &$find_accordion_data ) {
+	if ( 'fs-blocks/accordion-interactive' === $block_instance->name ) {
+		$items_data = [];
+		$first_item_id = '';
+		$first_media_item_id = '';
+		$accordion_opens_first = ! empty(
+			$block_instance->attributes['openFirstItem']
+		);
+
+		foreach ( $block_instance->inner_blocks as $accordion_item ) {
+			if ( 'fs-blocks/accordion-item-interactive' !== $accordion_item->name ) {
+				continue;
+			}
+
+			$item_id = isset( $accordion_item->attributes['itemId'] )
+				? sanitize_html_class( $accordion_item->attributes['itemId'] )
+				: '';
+			if ( '' === $item_id ) {
+				continue;
+			}
+
+			if ( '' === $first_item_id ) {
+				$first_item_id = $item_id;
+			}
+
+			$media_id = ! empty( $accordion_item->attributes['showcaseMediaId'] )
+				? (int) $accordion_item->attributes['showcaseMediaId']
+				: 0;
+
+			if ( $media_id ) {
+				$media_type = wp_attachment_is( 'video', $media_id )
+					? 'video'
+					: 'image';
+				$media_url = 'video' === $media_type
+					? wp_get_attachment_url( $media_id )
+					: wp_get_attachment_image_url( $media_id, 'large' );
+				$items_data[ $item_id ] = [
+					'id' => $media_id,
+					'url' => $media_url ? $media_url : '',
+					'type' => $media_type,
+					'alt' => 'image' === $media_type
+						? get_post_meta( $media_id, '_wp_attachment_image_alt', true )
+						: '',
+					'srcset' => 'image' === $media_type
+						? wp_get_attachment_image_srcset( $media_id, 'large' )
+						: '',
+					'hasMedia' => true,
+				];
+
+				if ( '' === $first_media_item_id ) {
+					$first_media_item_id = $item_id;
+				}
+			} else {
+				$items_data[ $item_id ] = [
+					'hasMedia' => false,
+				];
+			}
+		}
+
+		$active_item_id = '';
+		if (
+			$accordion_opens_first &&
+			'' !== $first_item_id &&
+			! empty( $items_data[ $first_item_id ]['hasMedia'] )
+		) {
+			$active_item_id = $first_item_id;
+		}
+		if ( '' === $active_item_id ) {
+			$active_item_id = $first_media_item_id;
+		}
+
+		return [
+			'itemsData' => $items_data,
+			'activeItemId' => $active_item_id,
+		];
+	}
+
+	if ( ! empty( $block_instance->inner_blocks ) ) {
+		foreach ( $block_instance->inner_blocks as $inner_block ) {
+			$result = $find_accordion_data( $inner_block );
+			if ( null !== $result ) {
+				return $result;
+			}
+		}
+	}
+
+	return null;
+};
+
+$stack_context = function_exists( 'fs_showcase_context_stack_peek' )
+	? fs_showcase_context_stack_peek()
+	: null;
+$accordion_data = is_array( $stack_context )
+	? $stack_context
+	: $find_accordion_data( $block );
+$items_data = $accordion_data['itemsData'] ?? [];
+$active_item_id = $accordion_data['activeItemId'] ?? '';
+
+$initial_context = [
+	'blockId' => $block_id,
+	'activeItemId' => $active_item_id,
+	'itemsData' => $items_data,
+	'sourceEventName' => $source_event_name,
+];
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	[
+		'class' => implode( ' ', array_filter( $classes ) ),
+	]
+);
+?>
+<div
+	<?php echo $wrapper_attributes; ?>
+	data-wp-interactive="fancySquaresContentShowcase"
+	<?php echo wp_interactivity_data_wp_context( $initial_context ); ?>
+	data-wp-init--showcase="callbacks.initShowcase"
+>
+	<?php echo $content; ?>
+</div>

--- a/src/blocks/content-showcase/style.scss
+++ b/src/blocks/content-showcase/style.scss
@@ -1,0 +1,27 @@
+.wp-block-fs-blocks-content-showcase {
+	display: grid;
+	gap: 2rem;
+	align-items: start;
+
+	&.fs-content-showcase--layout-two-column {
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	}
+
+	&.fs-content-showcase--layout-sidebar-left {
+		grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+	}
+
+	&.fs-content-showcase--layout-sidebar-right {
+		grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+	}
+
+	@media ( max-width: 767px ) {
+		grid-template-columns: minmax(0, 1fr);
+
+		&.fs-content-showcase--hide-gallery-mobile {
+			.wp-block-fs-blocks-showcase-gallery {
+				display: none;
+			}
+		}
+	}
+}

--- a/src/blocks/content-showcase/view.js
+++ b/src/blocks/content-showcase/view.js
@@ -1,0 +1,51 @@
+import { store, getContext, getElement } from '@wordpress/interactivity';
+
+store( 'fancySquaresContentShowcase', {
+	state: {
+		get isActiveMedia() {
+			const context = getContext();
+			return context.activeItemId === context.itemId;
+		},
+		get hasActiveMedia() {
+			const context = getContext();
+			return (
+				context.itemsData?.[ context.activeItemId ]?.hasMedia ?? false
+			);
+		},
+	},
+	callbacks: {
+		initShowcase() {
+			const context = getContext();
+			const { ref } = getElement();
+
+			if ( ! ref ) {
+				return;
+			}
+
+			const eventName =
+				context.sourceEventName && context.sourceEventName.trim()
+					? context.sourceEventName
+					: 'shown.fs.accordion';
+
+			const handleAccordionShown = ( event ) => {
+				const newItemId = event.detail?.itemId;
+				if ( ! newItemId ) {
+					return;
+				}
+
+				const hasMedia =
+					context.itemsData?.[ newItemId ]?.hasMedia ?? false;
+
+				if ( hasMedia ) {
+					context.activeItemId = newItemId;
+				}
+			};
+
+			ref.addEventListener( eventName, handleAccordionShown );
+
+			return () => {
+				ref.removeEventListener( eventName, handleAccordionShown );
+			};
+		},
+	},
+} );

--- a/src/blocks/showcase-gallery/block.json
+++ b/src/blocks/showcase-gallery/block.json
@@ -1,0 +1,38 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "fs-blocks/showcase-gallery",
+	"title": "FS Showcase Gallery",
+	"category": "media",
+	"icon": "format-gallery",
+	"description": "Media gallery synced to an interactive source such as an accordion.",
+	"keywords": [ "showcase", "gallery", "media" ],
+	"textdomain": "fancy-squares-core-enhancements",
+	"ancestor": [ "fs-blocks/content-showcase" ],
+	"supports": {
+		"html": false,
+		"anchor": true,
+		"interactivity": true
+	},
+	"attributes": {
+		"transitionType": {
+			"type": "string",
+			"default": "fade"
+		},
+		"transitionDuration": {
+			"type": "number",
+			"default": 300
+		},
+		"additionalClasses": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"default": []
+		}
+	},
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"editorStyle": "file:./index.css",
+	"render": "file:./render.php"
+}

--- a/src/blocks/showcase-gallery/edit.js
+++ b/src/blocks/showcase-gallery/edit.js
@@ -1,0 +1,86 @@
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, RangeControl } from '@wordpress/components';
+import { useEffect, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+import BlockEdit from '../../components/BlockEdit';
+import { generateClassName } from '../../utils/helpers';
+import { BLOCK_CONFIG } from '../../config/blockConfig';
+
+const TEXT_DOMAIN = 'fancy-squares-core-enhancements';
+
+const TRANSITION_OPTIONS = [
+	{ label: __( 'Fade', TEXT_DOMAIN ), value: 'fade' },
+	{ label: __( 'Slide', TEXT_DOMAIN ), value: 'slide' },
+	{ label: __( 'Zoom', TEXT_DOMAIN ), value: 'zoom' },
+];
+
+export default function Edit( props ) {
+	const { attributes, setAttributes, name } = props;
+	const {
+		transitionType,
+		transitionDuration,
+		additionalClasses,
+	} = attributes;
+
+	const generatedClassName = useMemo(
+		() => generateClassName( attributes, name, BLOCK_CONFIG ),
+		[ attributes, name ]
+	);
+
+	useEffect( () => {
+		const nextClasses = generatedClassName.split( /\s+/ ).filter( Boolean );
+		const currentClasses = Array.isArray( additionalClasses )
+			? additionalClasses
+			: [];
+		if ( currentClasses.join( ' ' ) !== nextClasses.join( ' ' ) ) {
+			setAttributes( { additionalClasses: nextClasses } );
+		}
+	}, [ additionalClasses, generatedClassName, setAttributes ] );
+
+	const blockProps = useBlockProps( {
+		className: [ 'fs-showcase-gallery-editor', generatedClassName ]
+			.filter( Boolean )
+			.join( ' ' ),
+	} );
+
+	return (
+		<>
+			<BlockEdit { ...props } />
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Gallery Settings', TEXT_DOMAIN ) }
+					initialOpen={ false }
+				>
+					<SelectControl
+						label={ __( 'Transition', TEXT_DOMAIN ) }
+						value={ transitionType }
+						options={ TRANSITION_OPTIONS }
+						onChange={ ( value ) =>
+							setAttributes( { transitionType: value } )
+						}
+					/>
+					<RangeControl
+						label={ __( 'Transition duration (ms)', TEXT_DOMAIN ) }
+						value={ transitionDuration }
+						onChange={ ( value ) =>
+							setAttributes( { transitionDuration: value } )
+						}
+						min={ 100 }
+						max={ 1000 }
+						step={ 50 }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<p>{ __( 'Showcase Gallery Preview', TEXT_DOMAIN ) }</p>
+				<p className="fs-showcase-gallery-editor__note">
+					{ __(
+						'Media renders on the front end based on the active item.',
+						TEXT_DOMAIN
+					) }
+				</p>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/showcase-gallery/edit.js
+++ b/src/blocks/showcase-gallery/edit.js
@@ -17,11 +17,8 @@ const TRANSITION_OPTIONS = [
 
 export default function Edit( props ) {
 	const { attributes, setAttributes, name } = props;
-	const {
-		transitionType,
-		transitionDuration,
-		additionalClasses,
-	} = attributes;
+	const { transitionType, transitionDuration, additionalClasses } =
+		attributes;
 
 	const generatedClassName = useMemo(
 		() => generateClassName( attributes, name, BLOCK_CONFIG ),

--- a/src/blocks/showcase-gallery/editor.scss
+++ b/src/blocks/showcase-gallery/editor.scss
@@ -1,0 +1,16 @@
+.fs-showcase-gallery-editor {
+	border: 1px dashed #d0d0d0;
+	padding: 1rem;
+	background: #fafafa;
+	text-align: center;
+
+	p {
+		margin: 0;
+	}
+
+	.fs-showcase-gallery-editor__note {
+		color: #666;
+		font-size: 12px;
+		margin-top: 0.5rem;
+	}
+}

--- a/src/blocks/showcase-gallery/index.js
+++ b/src/blocks/showcase-gallery/index.js
@@ -1,0 +1,22 @@
+import { registerBlockType } from '@wordpress/blocks';
+import metadata from './block.json';
+import edit from './edit';
+import { generateAttributes } from '../../utils/helpers';
+import './style.scss';
+import './editor.scss';
+
+export function registerShowcaseGalleryBlock() {
+	const attributes = {
+		...metadata.attributes,
+		...generateAttributes(),
+	};
+
+	registerBlockType( metadata.name, {
+		...metadata,
+		attributes,
+		edit,
+		save: () => null,
+	} );
+}
+
+registerShowcaseGalleryBlock();

--- a/src/blocks/showcase-gallery/render.php
+++ b/src/blocks/showcase-gallery/render.php
@@ -35,13 +35,28 @@ foreach ( $items_data as $item_id => $media_data ) {
 	if ( empty( $media_data['hasMedia'] ) ) {
 		continue;
 	}
+	$media_id = isset( $media_data['id'] ) ? (int) $media_data['id'] : 0;
+	if ( ! $media_id ) {
+		continue;
+	}
+
+	$media_type = wp_attachment_is( 'video', $media_id ) ? 'video' : 'image';
+	$media_url = 'video' === $media_type
+		? wp_get_attachment_url( $media_id )
+		: wp_get_attachment_image_url( $media_id, 'large' );
+	$media_alt = 'image' === $media_type
+		? get_post_meta( $media_id, '_wp_attachment_image_alt', true )
+		: '';
+	$media_srcset = 'image' === $media_type
+		? wp_get_attachment_image_srcset( $media_id, 'large' )
+		: '';
 
 	$items_list[] = [
 		'itemId' => sanitize_html_class( $item_id ),
-		'url' => isset( $media_data['url'] ) ? $media_data['url'] : '',
-		'type' => isset( $media_data['type'] ) ? $media_data['type'] : 'image',
-		'alt' => isset( $media_data['alt'] ) ? $media_data['alt'] : '',
-		'srcset' => isset( $media_data['srcset'] ) ? $media_data['srcset'] : '',
+		'url' => $media_url ? $media_url : '',
+		'type' => $media_type,
+		'alt' => $media_alt,
+		'srcset' => $media_srcset ? $media_srcset : '',
 	];
 }
 

--- a/src/blocks/showcase-gallery/render.php
+++ b/src/blocks/showcase-gallery/render.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Render callback for the Showcase Gallery block.
+ *
+ * @param array  $attributes Block attributes.
+ * @param string $content    Block inner content (unused).
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$stack_context = function_exists( 'fs_showcase_context_stack_peek' )
+	? fs_showcase_context_stack_peek()
+	: null;
+$items_data = is_array( $stack_context ) && isset( $stack_context['itemsData'] )
+	? $stack_context['itemsData']
+	: [];
+
+$transition_type = isset( $attributes['transitionType'] )
+	? sanitize_key( $attributes['transitionType'] )
+	: 'fade';
+$transition_duration = isset( $attributes['transitionDuration'] )
+	? (int) $attributes['transitionDuration']
+	: 300;
+$additional_classes = [];
+if ( ! empty( $attributes['additionalClasses'] ) && is_array( $attributes['additionalClasses'] ) ) {
+	foreach ( $attributes['additionalClasses'] as $class_name ) {
+		if ( is_string( $class_name ) && '' !== $class_name ) {
+			$additional_classes[] = sanitize_html_class( $class_name );
+		}
+	}
+}
+
+$items_list = [];
+foreach ( $items_data as $item_id => $media_data ) {
+	if ( empty( $media_data['hasMedia'] ) ) {
+		continue;
+	}
+
+	$items_list[] = [
+		'itemId' => sanitize_html_class( $item_id ),
+		'url' => isset( $media_data['url'] ) ? $media_data['url'] : '',
+		'type' => isset( $media_data['type'] ) ? $media_data['type'] : 'image',
+		'alt' => isset( $media_data['alt'] ) ? $media_data['alt'] : '',
+		'srcset' => isset( $media_data['srcset'] ) ? $media_data['srcset'] : '',
+	];
+}
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	[
+		'class' => implode(
+			' ',
+			array_filter(
+				array_merge(
+					[ 'fs-showcase-gallery' ],
+					$additional_classes
+				)
+			)
+		),
+		'data-transition' => $transition_type,
+		'data-transition-duration' => $transition_duration,
+		'style' => sprintf(
+			'--fs-showcase-transition: %dms;',
+			max( 100, $transition_duration )
+		),
+		'aria-live' => 'polite',
+	]
+);
+?>
+<div
+	<?php echo $wrapper_attributes; ?>
+	data-wp-class--has-no-media="!state.hasActiveMedia"
+>
+	<?php if ( empty( $items_list ) ) : ?>
+		<div class="showcase-gallery__placeholder">
+			<p><?php esc_html_e( 'No media available for this showcase.', 'fancy-squares-core-enhancements' ); ?></p>
+		</div>
+	<?php else : ?>
+		<?php foreach ( $items_list as $media ) : ?>
+			<div
+				class="showcase-gallery__media-wrapper"
+				<?php
+				echo wp_interactivity_data_wp_context(
+					[
+						'itemId' => $media['itemId'],
+					]
+				);
+				?>
+				data-wp-class--is-active="state.isActiveMedia"
+			>
+				<?php if ( 'video' === $media['type'] ) : ?>
+					<video
+						class="showcase-gallery__video"
+						data-fs-lazy-video="true"
+						data-src="<?php echo esc_url( $media['url'] ); ?>"
+						autoplay
+						muted
+						loop
+						playsinline
+					></video>
+				<?php else : ?>
+					<img
+						class="showcase-gallery__image"
+						src="<?php echo esc_url( $media['url'] ); ?>"
+						alt="<?php echo esc_attr( $media['alt'] ); ?>"
+						srcset="<?php echo esc_attr( $media['srcset'] ); ?>"
+						loading="lazy"
+						decoding="async"
+					/>
+				<?php endif; ?>
+			</div>
+		<?php endforeach; ?>
+	<?php endif; ?>
+</div>

--- a/src/blocks/showcase-gallery/style.scss
+++ b/src/blocks/showcase-gallery/style.scss
@@ -1,0 +1,75 @@
+.wp-block-fs-blocks-showcase-gallery {
+	--fs-showcase-transition: 300ms;
+	position: relative;
+	min-height: 320px;
+	overflow: hidden;
+
+	.showcase-gallery__media-wrapper {
+		position: absolute;
+		inset: 0;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity var(--fs-showcase-transition) ease-in-out;
+
+		&.is-active {
+			opacity: 1;
+			pointer-events: auto;
+			z-index: 1;
+		}
+	}
+
+	.showcase-gallery__image,
+	.showcase-gallery__video {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.showcase-gallery__video {
+		background: #000;
+	}
+
+	.showcase-gallery__placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 320px;
+		background: #f5f5f5;
+		color: #666;
+		text-align: center;
+		padding: 2rem;
+	}
+
+	&.has-no-media {
+		.showcase-gallery__media-wrapper {
+			opacity: 0.2;
+		}
+	}
+
+	&[data-transition='slide'] {
+		.showcase-gallery__media-wrapper {
+			transition:
+				transform var(--fs-showcase-transition) ease-in-out,
+				opacity var(--fs-showcase-transition) ease-in-out;
+			transform: translateX( 16px );
+
+			&.is-active {
+				transform: translateX( 0 );
+			}
+		}
+	}
+
+	&[data-transition='zoom'] {
+		.showcase-gallery__media-wrapper {
+			transition:
+				transform var(--fs-showcase-transition) ease-in-out,
+				opacity var(--fs-showcase-transition) ease-in-out;
+			transform: scale( 0.97 );
+
+			&.is-active {
+				transform: scale( 1 );
+			}
+		}
+	}
+}

--- a/src/blocks/tabs-interactive/block.json
+++ b/src/blocks/tabs-interactive/block.json
@@ -6,11 +6,7 @@
 	"category": "layout",
 	"icon": "admin-page",
 	"description": "Interactivity API-driven tabbed content container.",
-	"keywords": [
-		"tabs",
-		"navigation",
-		"interactivity"
-	],
+	"keywords": [ "tabs", "navigation", "interactivity" ],
 	"supports": {
 		"html": false,
 		"anchor": true,

--- a/src/config/blockConfig.js
+++ b/src/config/blockConfig.js
@@ -223,6 +223,48 @@ export const BLOCK_CONFIG = {
 			'left',
 		],
 	},
+	'fs-blocks/content-showcase': {
+		classOptions: [ 'display', 'position', 'zindex' ],
+		allowedPaddingControls: [
+			'all',
+			'horizontal',
+			'vertical',
+			'top',
+			'right',
+			'bottom',
+			'left',
+		],
+		allowedPositiveMarginControls: [
+			'all',
+			'horizontal',
+			'vertical',
+			'top',
+			'right',
+			'bottom',
+			'left',
+		],
+	},
+	'fs-blocks/showcase-gallery': {
+		classOptions: [ 'display', 'position', 'zindex' ],
+		allowedPaddingControls: [
+			'all',
+			'horizontal',
+			'vertical',
+			'top',
+			'right',
+			'bottom',
+			'left',
+		],
+		allowedPositiveMarginControls: [
+			'all',
+			'horizontal',
+			'vertical',
+			'top',
+			'right',
+			'bottom',
+			'left',
+		],
+	},
 	'fs-blocks/carousel': {
 		classOptions: [ 'display', 'position', 'zindex' ],
 		allowedPaddingControls: [


### PR DESCRIPTION
Introduce Content Showcase wrapper + Showcase Gallery blocks using Interactivity API local context.
Add showcase media picker to accordion items and render media on front end/mobile.
Add SSR context stack for render order, docs updates, and editor indicator.